### PR TITLE
Fixes confusing order of directions in output

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ def main():
     my_items = []
 
     while True:
-        direction = input('\nYou are in the main room. \nWhich direction would you like to go? \nPlease enter N (North), S (South), E (East) or W (West): ')
+        direction = input('\nYou are in the main room. \nWhich direction would you like to go? \nPlease enter N (North), E (East), S (South) or W (West): ')
 
         try:
             idx = rooms.index(direction)


### PR DESCRIPTION
This commit fixes the order of directions in the output statements. 

**Previous:**

```
direction = input('\nYou are in the main room. \nWhich direction would you like to go? \nPlease enter N (North), S (South), E (East) or W (West): ')
```

**New:**

```
direction = input('\nYou are in the main room. \nWhich direction would you like to go? \nPlease enter N (North), E (East), S (South) or W (West): ')
```